### PR TITLE
feat(events): flexible stream-json parsing without data loss

### DIFF
--- a/src/ai/context.rs
+++ b/src/ai/context.rs
@@ -91,7 +91,7 @@ impl ContextCompressor {
             | ClaudeEvent::ContentBlockStop { .. }
             | ClaudeEvent::ContentBlockDelta { .. }
             | ClaudeEvent::User { .. }
-            | ClaudeEvent::Unknown => String::new(),
+            | ClaudeEvent::Other(_) => String::new(),
         }
     }
 

--- a/src/ai/context.rs
+++ b/src/ai/context.rs
@@ -273,6 +273,7 @@ mod tests {
             agents: vec![],
             skills: vec![],
             slash_commands: vec![],
+            extras: std::collections::HashMap::new(),
         })];
 
         let result = compressor.compress(&events);

--- a/src/supervisor/runner.rs
+++ b/src/supervisor/runner.rs
@@ -860,6 +860,7 @@ mod tests {
             is_error: false,
             cost_usd: Some(0.05),
             duration_ms: Some(1000),
+            extras: std::collections::HashMap::new(),
         });
 
         tx.send(result_event).await.unwrap();

--- a/tests/cli/events_test.rs
+++ b/tests/cli/events_test.rs
@@ -215,6 +215,7 @@ fn is_terminal_for_result() {
         cost_usd: None,
         is_error: false,
         duration_ms: None,
+        extras: std::collections::HashMap::new(),
     });
     assert!(result.is_terminal());
 }
@@ -263,6 +264,7 @@ fn session_id_for_system_init() {
         agents: vec![],
         skills: vec![],
         slash_commands: vec![],
+        extras: std::collections::HashMap::new(),
     });
     assert_eq!(event.session_id(), Some("session_abc"));
 }
@@ -275,6 +277,7 @@ fn session_id_for_result() {
         is_error: false,
         cost_usd: None,
         duration_ms: None,
+        extras: std::collections::HashMap::new(),
     });
     assert_eq!(event.session_id(), Some("session_xyz"));
 }

--- a/tests/cli/integration_test.rs
+++ b/tests/cli/integration_test.rs
@@ -47,6 +47,7 @@ fn all_event_types_exported() {
         is_error: false,
         cost_usd: None,
         duration_ms: None,
+        extras: std::collections::HashMap::new(),
     };
     assert_eq!(result.result, "done");
 }
@@ -89,6 +90,7 @@ fn helper_methods_work() {
         is_error: false,
         cost_usd: Some(0.05),
         duration_ms: Some(1000),
+        extras: std::collections::HashMap::new(),
     });
     assert!(result_event.is_terminal());
     assert!(ClaudeEvent::MessageStop.is_terminal());

--- a/tests/cli/stream_test.rs
+++ b/tests/cli/stream_test.rs
@@ -84,7 +84,13 @@ fn parse_line_unknown_event_type() {
     let result = StreamParser::parse_line(line);
 
     assert!(result.is_ok());
-    assert!(matches!(result.unwrap(), ClaudeEvent::Unknown));
+    match result.unwrap() {
+        ClaudeEvent::Other(value) => {
+            assert_eq!(value.get("type").unwrap(), "future_event_type");
+            assert_eq!(value.get("data").unwrap(), "something");
+        }
+        _ => panic!("Expected Other variant"),
+    }
 }
 
 #[test]

--- a/tests/supervisor/runner_test.rs
+++ b/tests/supervisor/runner_test.rs
@@ -81,6 +81,7 @@ async fn supervisor_processes_system_init() {
         agents: vec![],
         skills: vec![],
         slash_commands: vec![],
+        extras: std::collections::HashMap::new(),
     }))
     .await
     .unwrap();
@@ -162,6 +163,7 @@ async fn supervisor_handles_result_event() {
         is_error: false,
         cost_usd: Some(0.05),
         duration_ms: Some(5000),
+        extras: std::collections::HashMap::new(),
     }))
     .await
     .unwrap();
@@ -242,6 +244,7 @@ fn supervisor_result_from_result_event() {
         is_error: false,
         cost_usd: Some(0.10),
         duration_ms: Some(2000),
+        extras: std::collections::HashMap::new(),
     };
 
     let result = SupervisorResult::from_result_event(&event);


### PR DESCRIPTION
## Summary
Complete implementation of lossless JSON parsing for Claude Code stream output.

## Changes
- `RawClaudeEvent` wrapper preserving original JSON
- `Other(Value)` variant for unknown event types (replaces unit `Unknown`)
- Custom deserializer/serializer for `ClaudeEvent`
- `parse_raw_line` and `parse_stdout_raw` in StreamParser
- `extras` maps in `SystemInit` and `ResultEvent` for forward compatibility

## Tests
566 tests passing